### PR TITLE
do not use second param for getTemplateGroup

### DIFF
--- a/src/Resources/contao/classes/DcaHelper.php
+++ b/src/Resources/contao/classes/DcaHelper.php
@@ -57,7 +57,7 @@ class DcaHelper extends \Backend
 			$intPid = $this->Input->get('id');
 		}
 
-		return $this->getTemplateGroup('rateit_', $intPid);
+		return $this->getTemplateGroup('rateit_');
 	}
 
 	/**

--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -136,7 +136,7 @@ class tl_module_rateit extends DcaHelper {
 			$intPid = $this->Input->get('id');
 		}
 
-		return $this->getTemplateGroup('mod_rateit_top', $intPid);
+		return $this->getTemplateGroup('mod_rateit_top');
 	}
 }
 ?>


### PR DESCRIPTION
Fixes the following error:

```
Argument 2 passed to Contao\Controller::getTemplateGroup() must be of the type array, null given, called in vendor/cgo-it/rate-it/src/Resources/contao/classes/DcaHelper.php on line 60
```

Having a second integer parameter is still a remnant from Contao 2. It was not a problem in Contao 3 and 4 since no second parameter was used by Contao. However, no in the newest version of Contao, there is a second parameter again - and it is of type array now.